### PR TITLE
ci: add flox submodule bump workflow

### DIFF
--- a/.github/workflows/bump-flox-submodule.yml
+++ b/.github/workflows/bump-flox-submodule.yml
@@ -1,0 +1,85 @@
+name: Bump flox submodule
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bump-flox-submodule
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync submodule config
+        run: |
+          git submodule sync -- external/flox
+          git config -f .gitmodules submodule.external/flox.branch master
+          git submodule sync -- external/flox
+
+      - name: Update flox submodule
+        id: update
+        run: |
+          set -e
+          old_sha=$(git ls-tree HEAD external/flox | awk '{print $3}')
+          echo "Previous SHA: $old_sha"
+          echo "old_sha=$old_sha" >> "$GITHUB_OUTPUT"
+          git submodule update --init --remote --depth 1 external/flox || {
+            echo "Retrying submodule update after failure..."
+            sleep 5
+            git submodule update --init --remote --depth 1 external/flox
+          }
+          new_sha=$(git ls-tree HEAD external/flox | awk '{print $3}')
+          echo "New SHA: $new_sha"
+          echo "new_sha=$new_sha" >> "$GITHUB_OUTPUT"
+          if [ "$old_sha" = "$new_sha" ]; then
+            echo "No submodule changes detected."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Submodule updated."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push changes
+        if: steps.update.outputs.changed == 'true'
+        run: |
+          git checkout -B ci/bump-flox
+          git add external/flox
+          git commit -m "chore: bump flox submodule to latest master"
+          git push --force origin ci/bump-flox
+
+      - name: Create or update PR
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_body=$(printf "Previous SHA: %s\nNew SHA: %s" "${{ steps.update.outputs.old_sha }}" "${{ steps.update.outputs.new_sha }}")
+          pr_number=$(gh pr list --head ci/bump-flox --state open --json number --jq '.[0].number')
+          if [ -z "$pr_number" ]; then
+            gh pr create --title "chore: bump flox submodule to latest master" --body "$pr_body" --base main --head ci/bump-flox --label ci --label dependencies
+            echo "Created PR"
+          else
+            gh pr edit "$pr_number" --body "$pr_body"
+            echo "Updated PR #$pr_number"
+          fi
+
+      - name: No changes
+        if: steps.update.outputs.changed != 'true'
+        run: echo "No changes in flox submodule."


### PR DESCRIPTION
## Summary
- add scheduled workflow to bump flox submodule and open PRs
- revert unnecessary .gitmodules change

## Testing
- `./scripts/check-format.sh`
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement)*
- `yamllint .github/workflows/bump-flox-submodule.yml` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a0e18869d8832eab18b92f364a248a