### PR TITLE
fix: WS reconnect race condition, Bybit heartbeat

### DIFF
--- a/include/flox-connectors/bybit/bybit_exchange_connector.h
+++ b/include/flox-connectors/bybit/bybit_exchange_connector.h
@@ -92,6 +92,7 @@ class BybitExchangeConnector : public IExchangeConnector
 
   pool::Pool<BookUpdateEvent, config::DEFAULT_CONNECTOR_POOL_CAPACITY> _bookPool;
   OrderExecutionBus* _orderBus = nullptr;
+  std::thread _pingThread;
 };
 
 }  // namespace flox

--- a/src/bitget/bitget_exchange_connector.cpp
+++ b/src/bitget/bitget_exchange_connector.cpp
@@ -431,7 +431,7 @@ void BitgetExchangeConnector::handleMessage(std::string_view payload)
 
       if (!ev->update.bids.empty() || !ev->update.asks.empty())
       {
-        auto [res, _] = _bookUpdateBus->tryPublish(std::move(ev), std::chrono::microseconds(0));
+        auto [res, _] = _bookUpdateBus->tryPublish(std::move(ev));
         if (res != BookUpdateBus::PublishResult::SUCCESS)
         {
           _logger->error(
@@ -483,7 +483,7 @@ void BitgetExchangeConnector::handleMessage(std::string_view payload)
           }
         }
 
-        auto [res, _] = _tradeBus->tryPublish(ev, std::chrono::microseconds(0));
+        auto [res, _] = _tradeBus->tryPublish(ev);
         if (res != TradeBus::PublishResult::SUCCESS)
         {
           _logger->error(

--- a/src/bybit/bybit_exchange_connector.cpp
+++ b/src/bybit/bybit_exchange_connector.cpp
@@ -238,6 +238,29 @@ void BybitExchangeConnector::start()
 
   _wsClient->start();
 
+  // Application-level ping thread (Bybit requires {"op":"ping"} every 20s)
+  _pingThread = std::thread(
+      [this]()
+      {
+        // Wait for initial connection
+        for (int i = 0; i < 50 && _running.load(); ++i)
+        {
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+
+        while (_running.load())
+        {
+          if (_wsClient)
+          {
+            _wsClient->send(R"({"op":"ping"})");
+          }
+          for (int i = 0; i < 200 && _running.load(); ++i)
+          {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          }
+        }
+      });
+
   if (_config.enablePrivate)
   {
     _wsClientPrivate = std::make_unique<IxWebSocketClient>(
@@ -276,6 +299,11 @@ void BybitExchangeConnector::stop()
     return;
   }
 
+  if (_pingThread.joinable())
+  {
+    _pingThread.join();
+  }
+
   if (_wsClient)
   {
     _wsClient->stop();
@@ -308,6 +336,11 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
       if (!op_field.error())
       {
         auto op = op_field.get_string().value();
+        if (op == "ping")
+        {
+          _wsClient->send(R"({"op":"pong"})");
+          return;
+        }
         if (op == "subscribe")
         {
           auto success_field = root.find_field_unordered("success");
@@ -443,7 +476,7 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
       if (!ev->update.bids.empty() || !ev->update.asks.empty())
       {
         ev->publishTsNs = nowNsMonotonic();
-        auto [res, _] = _bookUpdateBus->tryPublish(std::move(ev), std::chrono::microseconds(0));
+        auto [res, _] = _bookUpdateBus->tryPublish(std::move(ev));
         if (res != BookUpdateBus::PublishResult::SUCCESS)
         {
           _logger->error(
@@ -495,7 +528,7 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
         ev.trade.quantity = Quantity::fromDouble(*qtyOpt);
 
         ev.publishTsNs = nowNsMonotonic();
-        auto [res, _] = _tradeBus->tryPublish(ev, std::chrono::microseconds(0));
+        auto [res, _] = _tradeBus->tryPublish(ev);
         if (res != TradeBus::PublishResult::SUCCESS)
         {
           _logger->error(

--- a/src/hyperliquid/hyperliquid_exchange_connector.cpp
+++ b/src/hyperliquid/hyperliquid_exchange_connector.cpp
@@ -275,7 +275,7 @@ void HyperliquidExchangeConnector::handleMessage(std::string_view payload)
 
       if (!ev->update.bids.empty() || !ev->update.asks.empty())
       {
-        auto [res, _] = _bookBus->tryPublish(std::move(ev), std::chrono::microseconds(0));
+        auto [res, _] = _bookBus->tryPublish(std::move(ev));
         if (res != BookUpdateBus::PublishResult::SUCCESS)
         {
           _logger->error(
@@ -330,7 +330,7 @@ void HyperliquidExchangeConnector::handleMessage(std::string_view payload)
           ev.trade.instrument = info->type;
         }
 
-        auto [res, _] = _tradeBus->tryPublish(ev, std::chrono::microseconds(0));
+        auto [res, _] = _tradeBus->tryPublish(ev);
         if (res != TradeBus::PublishResult::SUCCESS)
         {
           _logger->error(

--- a/src/net/ix_websocket_client.cpp
+++ b/src/net/ix_websocket_client.cpp
@@ -77,31 +77,30 @@ void IxWebSocketClient::run()
 {
   constexpr int MAX_BACKOFF_MS = 30000;
 
-  bool firstAttempt = true;
-
   while (_running)
   {
-    // On reconnect, replace the socket with a fresh instance to avoid
-    // stale TLS context / frame buffers from the previous connection.
-    if (!firstAttempt)
+    // Fresh socket every attempt — avoids stale TLS/frame state
     {
-      _ws->disableAutomaticReconnection();
-      _ws->stop();
+      std::lock_guard lock(_sendMutex);
+      _ws = std::make_unique<ix::WebSocket>();
+    }
+
+    _ws->disableAutomaticReconnection();
+    _ws->setUrl(_url);
+    if (!_origin.empty())
+    {
+      if (_userAgent.empty())
       {
-        std::lock_guard lock(_sendMutex);
-        _ws = std::make_unique<ix::WebSocket>();
+        _ws->setExtraHeaders({{"Origin", _origin}});
+      }
+      else
+      {
+        _ws->setExtraHeaders({{"Origin", _origin}, {"User-Agent", _userAgent}});
       }
     }
-    firstAttempt = false;
-
-    _ws->setUrl(_url);
-    if (_userAgent.empty())
+    else if (!_userAgent.empty())
     {
-      _ws->setExtraHeaders({{"Origin", _origin}});
-    }
-    else
-    {
-      _ws->setExtraHeaders({{"Origin", _origin}, {"User-Agent", _userAgent}});
+      _ws->setExtraHeaders({{"User-Agent", _userAgent}});
     }
     _ws->disablePerMessageDeflate();
     if (_pingIntervalSec > 0)
@@ -113,8 +112,12 @@ void IxWebSocketClient::run()
       _ws->setPingInterval(-1);
     }
 
+    // Local flag — only THIS iteration's callbacks can set it.
+    // Eliminates race between old socket callbacks and new socket state.
+    std::atomic<bool> connectionClosed{false};
+
     _ws->setOnMessageCallback(
-        [this](const ix::WebSocketMessagePtr& msg)
+        [this, &connectionClosed](const ix::WebSocketMessagePtr& msg)
         {
           switch (msg->type)
           {
@@ -125,8 +128,8 @@ void IxWebSocketClient::run()
               {
                 _onOpen();
               }
-
               break;
+
             case ix::WebSocketMessageType::Message:
               if (_onMessage)
               {
@@ -139,10 +142,13 @@ void IxWebSocketClient::run()
               {
                 _onClose(msg->closeInfo.code, msg->closeInfo.reason);
               }
+              connectionClosed.store(true, std::memory_order_release);
               break;
+
             case ix::WebSocketMessageType::Error:
               _logger->error("WebSocket error connecting to " + _url + ": " +
                              msg->errorInfo.reason);
+              connectionClosed.store(true, std::memory_order_release);
               break;
 
             default:
@@ -152,15 +158,14 @@ void IxWebSocketClient::run()
 
     _ws->start();
 
-    while (_running)
+    // Wait for close/error callback or stop signal — NOT polling getReadyState()
+    while (_running && !connectionClosed.load(std::memory_order_acquire))
     {
-      auto state = _ws->getReadyState();
-      if (state == ix::ReadyState::Closed || state == ix::ReadyState::Closing)
-      {
-        break;
-      }
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
+
+    // Ensure socket is fully stopped before creating a new one
+    _ws->stop();
 
     if (_running)
     {


### PR DESCRIPTION
IxWebSocketClient:
- Replace getReadyState() polling with callback-driven atomic flag. Fixes race where fresh socket returns Closed before handshake, causing reconnect every ~4 seconds.
- Create fresh socket per attempt, disable auto-reconnection.

Bybit:
- Respond to application-level {"op":"ping"} with {"op":"pong"}.
- Add ping thread (20s interval) matching Bitget/Hyperliquid pattern.

All connectors:
- Remove explicit tryPublish timeout, use core default (1ms).